### PR TITLE
UTF-8 header in html output for displaying UTF-8 characters correct

### DIFF
--- a/readinglist2html.py
+++ b/readinglist2html.py
@@ -5,7 +5,7 @@ from readinglistlib import ReadingListReader
 rlr = ReadingListReader()
 bookmarks = rlr.read(ascending=False)
 
-print '<!DOCTYPE html><html><head><title>Reading List</title></head><body><h1>Reading List</h1><ul>'
+print '<!DOCTYPE html><html><head><meta charset="utf-8"><title>Reading List</title></head><body><h1>Reading List</h1><ul>'
 
 for bookmark in bookmarks:
 	print '<li><p><a href="%(url)s">%(title)s</a><br />%(url)s</p><blockquote>%(preview)s</blockquote></li>' % {'url': bookmark['url'].encode('utf-8'), 'title': bookmark['title'].encode('utf-8'), 'preview': bookmark['preview'].encode('utf-8')}


### PR DESCRIPTION
Looks like the export works with UTF-8 characters, but they are not displayed correctly. With the correct header in the HTML head, it works fine.
